### PR TITLE
[PKG-2343] libavif 0.11.1

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,7 +3,7 @@ cd build
 if errorlevel 1 exit /b 1
 
 :: Other codecs cannot be enabled because they are not on default
-cmake .. -G Ninja                                 ^
+cmake .. -G Ninja                                ^
   -DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%" ^
   -DCMAKE_PREFIX_PATH:PATH="%LIBRARY_PREFIX%"    ^
   -DCMAKE_INSTALL_LIBDIR=lib                     ^

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,8 +2,8 @@ mkdir build
 cd build
 if errorlevel 1 exit /b 1
 
-:: Other codecs cannot be enabled because they are not on conda-forge
-cmake .. -GNinja                                 ^
+:: Other codecs cannot be enabled because they are not on default
+cmake .. -G Ninja                                 ^
   -DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%" ^
   -DCMAKE_PREFIX_PATH:PATH="%LIBRARY_PREFIX%"    ^
   -DCMAKE_INSTALL_LIBDIR=lib                     ^
@@ -13,7 +13,8 @@ cmake .. -GNinja                                 ^
   -DAVIF_CODEC_AOM=ON                            ^
   -DAVIF_CODEC_SVT=OFF                           ^
   -DAVIF_CODEC_DAV1D=ON                          ^
-  -DAVIF_CODEC_LIBGAV1=OFF
+  -DAVIF_CODEC_LIBGAV1=OFF                       ^
+  -DAVIF_ENABLE_WERROR=OFF
 if errorlevel 1 exit /b 1
 
 ninja

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,5 @@
-mkdir build
-cd build
+mkdir build && cd build
+
 # 2022/04/07 hmaarrfk:
 # Tests have strange dependencies, which aren't required for the
 # actual application
@@ -8,8 +8,8 @@ cd build
 # https://github.com/AOMediaCodec/libavif/issues/798
 AVIF_BUILD_TESTS=OFF
 
-# Other codecs cannot be enabled because they are not on conda-forge
-cmake .. "${CMAKE_ARGS}" -GNinja \
+# Other codecs cannot be enabled because they are not on default
+cmake .. ${CMAKE_ARGS} -G Ninja \
 -DCMAKE_INSTALL_PREFIX="$PREFIX" \
 -DCMAKE_INSTALL_LIBDIR=lib \
 -DBUILD_SHARED_LIBS=ON \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ build:
     # The SO name changes every version
     # https://github.com/AOMediaCodec/libavif/issues/799
     - {{ pin_subpackage('libavif', min_pin='x.x.x', max_pin='x.x.x') }}
-  number: 2
+  number: 0
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "libavif" %}
-# NOTE: Humans must also update the library version in the tests section of this recipe
 {% set version = "0.11.1" %}
+# NOTE: Humans must also update the library version in so_version
 # Look in the libavif top level CMakeLists.txt for the updated library
 # version (not the same as the project version) to update parameters for existence checks
 {% set so_version = "15.0.1" %}
@@ -31,9 +31,6 @@ requirements:
   host:
     - aom 3.6.0
     - dav1d 1.2.1
-    # - libpng
-    # - jpeg
-    # - svt-av1  # TODO: linking error with this optional library
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,7 +57,7 @@ test:
     - if not exist %PREFIX%\\Library\\lib\\cmake\\libavif\\libavif-config-version.cmake exit 1  # [win]
 
 about:
-  home: https://github.com/AOMediaCodec/libavif
+  home: https://aomediacodec.github.io/av1-avif/
   license: BSD-2-Clause
   license_family: BSD
   license_file: LICENSE
@@ -66,7 +66,7 @@ about:
     This library aims to be a friendly, portable C implementation of the AV1
     Image File Format, as described here
     <https://aomediacodec.github.io/av1-avif/>.
-  doc_url: https://github.com/AOMediaCodec/libavif
+  doc_url: https://aomediacodec.github.io/av1-avif/
   dev_url: https://github.com/AOMediaCodec/libavif
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
   build:
     - cmake
     - {{ compiler('c') }}
-    - nasm
+    - nasm  # [x86_64]
     - ninja
     - meson
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,6 @@ requirements:
     - {{ compiler('c') }}
     - nasm  # [x86_64]
     - ninja
-    - meson
   host:
     - aom 3.6.0
     - dav1d 1.2.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,8 +30,8 @@ requirements:
     - ninja
     - meson
   host:
-    - aom
-    - dav1d
+    - aom 3.6.0
+    - dav1d 1.2.1
     # - libpng
     # - jpeg
     # - svt-av1  # TODO: linking error with this optional library
@@ -66,6 +66,8 @@ about:
     This library aims to be a friendly, portable C implementation of the AV1
     Image File Format, as described here
     <https://aomediacodec.github.io/av1-avif/>.
+  doc_url: https://github.com/AOMediaCodec/libavif
+  dev_url: https://github.com/AOMediaCodec/libavif
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
[PKG-2343] libavif 0.11.1

- upstream: https://github.com/AOMediaCodec/libavif/tree/v0.11.1
- conda-forge: https://github.com/conda-forge/libavif-feedstock/blob/main/recipe/meta.yaml
- linter
- pin `aom` and `dav1d`
- `win`: disable warnings as errors with `AVIF_ENABLE_WERROR=OFF`
- remove `meson` (it is needed to build `dav1d`, but that's coming from the `default`)
- update comments, remove commented out dependencies

[PKG-2343]: https://anaconda.atlassian.net/browse/PKG-2343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ