### PR TITLE
Update version to 1.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: 0a545e953cc049bf5bcf4ee467306a2f113a75110edf59e61248873101cd26c1
 
 build:
-  number: 1
+  number: 0
   run_exports:
     - {{ pin_subpackage('libavif', max_pin='x') }}
 
@@ -24,11 +24,11 @@ requirements:
     - cmake
     - {{ compiler('c') }}
     - {{ stdlib('c') }}
-    - m2-sed  # [win]
-    - ninja
+    - msys2-sed  # [win]
+    - ninja-base
   host:
     - aom {{ aom }}
-    - dav1d 1.2.1
+    - dav1d {{ dav1d }}
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
-# NOTE: Humans must also update the library version in so_version
 {% set name = "libavif" %}
-{% set version = "1.1.1" %}
+{% set version = "1.3.0" %}
 # Look in the libavif top level CMakeLists.txt for the updated library
 # version (not the same as the project version) to update parameters for existence checks
 # The SO name changes every version https://github.com/AOMediaCodec/libavif/issues/799
@@ -13,7 +12,7 @@ package:
 
 source:
   url: https://github.com/AOMediaCodec/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 914662e16245e062ed73f90112fbb4548241300843a7772d8d441bb6859de45b
+  sha256: 0a545e953cc049bf5bcf4ee467306a2f113a75110edf59e61248873101cd26c1
 
 build:
   number: 1
@@ -24,7 +23,8 @@ requirements:
   build:
     - cmake
     - {{ compiler('c') }}
-    - nasm  # [x86_64]
+    - {{ stdlib('c') }}
+    - m2-sed  # [win]
     - ninja
   host:
     - aom {{ aom }}
@@ -53,7 +53,7 @@ test:
     - if not exist %PREFIX%\\Library\\lib\\cmake\\libavif\\libavif-config-version.cmake exit 1  # [win]
 
 about:
-  home: https://aomediacodec.github.io/av1-avif/
+  home: https://aomediacodec.github.io/av1-avif
   license: BSD-2-Clause
   license_family: BSD
   license_file: LICENSE
@@ -62,7 +62,7 @@ about:
     This library aims to be a friendly, portable C implementation of the AV1
     Image File Format, as described here
     <https://aomediacodec.github.io/av1-avif/>.
-  doc_url: https://aomediacodec.github.io/av1-avif/
+  doc_url: https://aomediacodec.github.io/av1-avif
   dev_url: https://github.com/AOMediaCodec/libavif
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,9 @@ requirements:
   host:
     - aom {{ aom }}
     - dav1d {{ dav1d }}
+  run:
+    - aom
+    - dav1d
 
 test:
   commands:


### PR DESCRIPTION
libavif 1.3.0

**Destination channel:**  defaults

### Links

- [PKG-10826](https://anaconda.atlassian.net/browse/PKG-10826) 
- [Upstream repository](https://github.com/AOMediaCodec/libavif/tree/v1.3.0)

### Explanation of changes:

- Update version number
- update dependency versions

[PKG-10826]: https://anaconda.atlassian.net/browse/PKG-10826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ